### PR TITLE
remove Windows build (temp)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,6 @@ jobs:
         GOARCH: amd64
         GOOS: linux
         CGO_ENABLED: 0
-    - name: release windows/amd64
-      uses: ngs/go-release.action@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GOARCH: amd64
-        GOOS: windows
     - name: release darwin/amd64
       uses: ngs/go-release.action@v1.0.1
       env:


### PR DESCRIPTION
Windows build fail and now I don't think anyone uses it on windows at all, so temporarily disable binary distribution for windows.