### PR TITLE
Add installation steps for MacPorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ and protect your data with a password.
 Download the latest version of the application
 from the [releases page](https://github.com/yitsushi/totp-cli/releases/latest).
 
+Users on macOS can also install the package using [MacPorts](https://ports.macports.org/port/totp-cli/summary):
+
+```
+sudo port selfupdate
+sudo port install totp-cli
+```
+
 ### Update
 
 ```


### PR DESCRIPTION
Hi! Thanks for creating this tool. I noticed that it was missing from the MacPorts package manager on macOS, so I added the package and created this PR for updating the README with installation steps. Please take a look at https://ports.macports.org/port/totp-cli/summary for more details.

Relevant links:

* MacPorts: https://www.macports.org/
* Installation Config: https://github.com/macports/macports-ports/blob/master/security/totp-cli/Portfile