### PR TITLE
feat: ability to clear prefix

### DIFF
--- a/internal/cmd/set_prefix.go
+++ b/internal/cmd/set_prefix.go
@@ -88,6 +88,9 @@ func (c *SetPrefix) Examples() []string {
 func NewSetPrefix(appName string) *commander.CommandWrapper {
 	return &commander.CommandWrapper{
 		Handler: &SetPrefix{},
+		Arguments: []*commander.Argument{
+			{Name: "clear", Type: "bool"},
+		},
 		Help: &commander.CommandDescriptor{
 			Name:             "set-prefix",
 			ShortDescription: "Set prefix for a token",
@@ -117,6 +120,10 @@ func (c *SetPrefix) askForSetPrefixDetails(opts *commander.CommandHelper) (strin
 	account = opts.Arg(argPositionAccount)
 	for len(account) < 1 {
 		account, _ = term.Read("Account:")
+	}
+
+	if opts.Flag("clear") {
+		return namespace, account, ""
 	}
 
 	prefix = opts.Arg(argPositionPrefix)


### PR DESCRIPTION
New flag on set-prefix: `--clear`

```
❯ TOTP_CLI_CREDENTIAL_FILE=/tmp/totp.test go run . generate ns acc
Password: ***
811874

❯ TOTP_CLI_CREDENTIAL_FILE=/tmp/totp.test go run . set-prefix ns acc pref
Password: ***

❯ TOTP_CLI_CREDENTIAL_FILE=/tmp/totp.test go run . generate ns acc
Password: ***
pref811874

❯ TOTP_CLI_CREDENTIAL_FILE=/tmp/totp.test go run . set-prefix ns acc --clear
Password: ***

❯ TOTP_CLI_CREDENTIAL_FILE=/tmp/totp.test go run . generate ns acc
Password: ***
249213
```

Closes #47

References:
* https://github.com/yitsushi/totp-cli/issues/47