### PR TITLE
add follow option to generate + sort accounts on list

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,26 @@ totp-cli set-prefix ns account myprefix
 totp-cli set-prefix ns account --clear
 ```
 
+To generate an OTP, you simply use the `generate` command like:
+
+```shell
+totp-cli generate namespace account
+Password: ***
+889840
+```
+
+You can also use the `--follow` flag on the `generate` command if you want to 
+have the OTP token automatically refreshed once expired:
+
+```shell
+totp-cli generate --follow namespace account
+Password: ***
+889840
+343555
+463346
+```
+
+
 ### Changing the location of the credentials file
 
 Simply put this into your `.zshrc` (or `.{YourShell}rc` or `.profile`):

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -30,6 +30,12 @@ func (c *Generate) Execute(opts *commander.CommandHelper) {
 		return
 	}
 
+	mustFollow := false
+	follow := opts.Arg(2)
+	if len(follow) > 0 && follow == "follow" {
+		mustFollow = true
+	}
+
 	storage, err := s.PrepareStorage()
 	if err != nil {
 		fmt.Printf("Error: %s\n", err.Error())
@@ -48,6 +54,23 @@ func (c *Generate) Execute(opts *commander.CommandHelper) {
 		os.Exit(1)
 	}
 
+	if !mustFollow {
+		code := generateCode(account)
+		fmt.Println(code)
+	} else {
+		previousCode := ""
+		for {
+			code := generateCode(account)
+			if code != previousCode {
+				fmt.Println(code)
+				previousCode = code
+			}
+			time.Sleep(time.Second)
+		}
+	}
+}
+
+func generateCode(account *s.Account) string {
 	code, err := security.GenerateOTPCode(account.Token, time.Now())
 	if err != nil {
 		fmt.Printf("Error: %s\n", err.Error())
@@ -56,8 +79,7 @@ func (c *Generate) Execute(opts *commander.CommandHelper) {
 	if account.Prefix != "" {
 		code = account.Prefix + code
 	}
-
-	fmt.Println(code)
+	return code
 }
 
 // NewGenerate creates a new Generate command.
@@ -67,8 +89,8 @@ func NewGenerate(appName string) *commander.CommandWrapper {
 		Help: &commander.CommandDescriptor{
 			Name:             "generate",
 			ShortDescription: "Generate a specific OTP",
-			Arguments:        "<namespace> <account>",
-			Examples:         []string{"mynamespace myaccount"},
+			Arguments:        "<namespace> <account> [follow]",
+			Examples:         []string{"mynamespace myaccount", "mynamespace myaccount follow"},
 		},
 	}
 }

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -30,11 +30,7 @@ func (c *Generate) Execute(opts *commander.CommandHelper) {
 		return
 	}
 
-	mustFollow := false
-	follow := opts.Arg(2)
-	if len(follow) > 0 && follow == "follow" {
-		mustFollow = true
-	}
+	mustFollow := opts.Flag("follow")
 
 	storage, err := s.PrepareStorage()
 	if err != nil {
@@ -54,19 +50,21 @@ func (c *Generate) Execute(opts *commander.CommandHelper) {
 		os.Exit(1)
 	}
 
+	code := generateCode(account)
+	fmt.Println(code)
+
 	if !mustFollow {
+		return
+	}
+
+	previousCode := code
+	for {
 		code := generateCode(account)
-		fmt.Println(code)
-	} else {
-		previousCode := ""
-		for {
-			code := generateCode(account)
-			if code != previousCode {
-				fmt.Println(code)
-				previousCode = code
-			}
-			time.Sleep(time.Second)
+		if code != previousCode {
+			fmt.Println(code)
+			previousCode = code
 		}
+		time.Sleep(time.Second)
 	}
 }
 
@@ -86,11 +84,14 @@ func generateCode(account *s.Account) string {
 func NewGenerate(appName string) *commander.CommandWrapper {
 	return &commander.CommandWrapper{
 		Handler: &Generate{},
+		Arguments: []*commander.Argument{
+			{Name: "follow", Type: "bool", Value: false},
+		},
 		Help: &commander.CommandDescriptor{
 			Name:             "generate",
 			ShortDescription: "Generate a specific OTP",
-			Arguments:        "<namespace> <account> [follow]",
-			Examples:         []string{"mynamespace myaccount", "mynamespace myaccount follow"},
+			Arguments:        "<namespace> <account>",
+			Examples:         []string{"mynamespace myaccount"},
 		},
 	}
 }

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -58,12 +58,14 @@ func (c *Generate) Execute(opts *commander.CommandHelper) {
 	}
 
 	previousCode := code
+
 	for {
 		code := generateCode(account)
 		if code != previousCode {
 			fmt.Println(code)
 			previousCode = code
 		}
+
 		time.Sleep(time.Second)
 	}
 }
@@ -77,6 +79,7 @@ func generateCode(account *s.Account) string {
 	if account.Prefix != "" {
 		code = account.Prefix + code
 	}
+
 	return code
 }
 

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/yitsushi/go-commander"
 
@@ -34,6 +35,10 @@ func (c *List) Execute(opts *commander.CommandHelper) {
 		fmt.Printf("Error: %s", err.Error())
 		os.Exit(1)
 	}
+
+	sort.Slice(namespace.Accounts, func(i, j int) bool {
+		return namespace.Accounts[i].Name < namespace.Accounts[j].Name
+	})
 
 	for _, account := range namespace.Accounts {
 		fmt.Printf("%s.%s\n", namespace.Name, account.Name)


### PR DESCRIPTION
### Description

Presently, a call to `generate` command returns the current `totp` code and exits. 
This PR is a proposal to add a `follow` parameter for the `generate` command so that the `generate` command continues generating `totp` code until stopped by the user.
The code is then generated every second and only printed on the console whenever it changes.

This PR also adds the sorting of accounts (by names) on the `list` command for convenience.
