### PR TITLE
feat: support setting passphrase through environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,10 +260,13 @@ compinit
 ## About the password
 
 The password should never be passed directly to any applications to unlock it.
-Because of that, `totp-cli` will not support any features like that, type in the
-password. If you save it in a variable it can be exposed if your `ENV` is
-exposed somehow, if you directly type in the password in the command line, it
-can end up in your bash/zsh/whatevershell history.
+If you save it in a variable it can be exposed if your `ENV` is exposed somehow,
+if you directly type in the password in the command line, it can end up in your
+bash/zsh/whatevershell history.
+
+Mostly to support CD/CI automation, there is an option to set the
+password/passphrase as an environment variable. **Please use it only if you know
+the system is safe to store passwords in environment variables.**
 
 If you really want to skip the password prompt, it reads from `stdin`, so you
 can pipe the password.
@@ -290,6 +293,24 @@ Password: ***
 ❯ totp-pass-in| totp-cli generate xxxxx xxxxx
 Password: ***
 889840
+```
+
+Other option is to use environment variable:
+
+```
+❯ age \
+  --encrypt \
+  --armor \
+  --recipient age15velesv0zwpsc5w0n4da5tv64u9fzuhl8hjpvdmeayjg00fdf4wsxl834c \
+  > "${HOME}/.config/totp-cli/totp-password.age"
+myapssword
+^D
+
+❯ export TOTP_PASS=$(age --decrypt --identity ~/.age/efertone.txt ~/.config/totp-cli/totp-password.age)
+Password: ***
+
+❯ totp-cli generate xxxxx xxxxx
+166307
 ```
 
 But I'm really against it, it's a password that can access all your stored 2FA

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -218,9 +218,12 @@ func PrepareStorage() (*Storage, error) {
 	if storage == nil {
 		term := terminal.New(os.Stdin, os.Stdout, os.Stderr)
 
-		password, termErr := term.Hidden("Password:")
-		if termErr != nil {
-			return nil, BackendError{Message: err.Error()}
+		password := os.Getenv("TOTP_PASS")
+
+		if password == "" {
+			if password, err = term.Hidden("Password:"); err != nil {
+				return nil, BackendError{Message: err.Error()}
+			}
 		}
 
 		storage = &Storage{


### PR DESCRIPTION
I know I said it'll not be supported. I reconsidered and I think most people wants to store it as an environment variable, they are already doing it anyway. I added some warnings in the readme about it.

Closes #76

References:
* https://github.com/yitsushi/totp-cli/issues/76
* https://github.com/yitsushi/totp-cli/issues/63