### PR TITLE
feat: ability to display time until code invalidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,13 @@ from the [releases page](https://github.com/yitsushi/totp-cli/releases/latest) o
 go install github.com/yitsushi/totp-cli@latest
 ```
 
-Users on macOS can also install the package using [MacPorts](https://ports.macports.org/port/totp-cli/summary):
+#### Aletrnative
 
+I'm not the maintainer of the MacPorts or the Homebrew package, if it's outdated
+please contact with the maintainer.
+
+
+Users on macOS can also install the package using [MacPorts](https://ports.macports.org/port/totp-cli/summary):
 ```shell
 sudo port selfupdate
 sudo port install totp-cli
@@ -199,6 +204,14 @@ Password: ***
 463346
 ```
 
+If the provider is very strict with the code, with the `--show-remaining` flag
+will add extra information about how long the code will be valid.
+
+```
+totp-cli generate --show-remaining namespace account
+Password: ***
+316762 (remaining time: 17s)
+```
 
 ### Changing the location of the credentials file
 

--- a/internal/cmd/generatehelper.go
+++ b/internal/cmd/generatehelper.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/yitsushi/totp-cli/internal/security"
+	s "github.com/yitsushi/totp-cli/internal/storage"
+)
+
+func formatCode(code string, remaining int64, showRemaining bool) string {
+	if showRemaining {
+		return fmt.Sprintf("%s (remaining time: %ds)", code, remaining)
+	}
+
+	return code
+}
+
+func generateCode(account *s.Account) (string, int64) {
+	code, remaining, err := security.GenerateOTPCode(account.Token, time.Now(), account.Length)
+	if err != nil {
+		fmt.Printf("Error: %s\n", err.Error())
+
+		return "", 0
+	}
+
+	if account.Prefix != "" {
+		code = account.Prefix + code
+	}
+
+	return code, remaining
+}

--- a/internal/cmd/instant.go
+++ b/internal/cmd/instant.go
@@ -24,6 +24,11 @@ func InstantCommand() *cli.Command {
 				Value: storage.DefaultTokenLength,
 				Usage: "Length of the generated token.",
 			},
+			&cli.BoolFlag{
+				Name:  "show-remaining",
+				Value: false,
+				Usage: "Show how much time left until the code will be invalid.",
+			},
 		},
 		Action: func(ctx *cli.Context) error {
 			token := os.Getenv("TOTP_TOKEN")
@@ -34,12 +39,12 @@ func InstantCommand() *cli.Command {
 
 			length := ctx.Uint("length")
 
-			code, err := security.GenerateOTPCode(token, time.Now(), length)
+			code, remaining, err := security.GenerateOTPCode(token, time.Now(), length)
 			if err != nil {
 				return err
 			}
 
-			fmt.Println(code)
+			fmt.Println(formatCode(code, remaining, ctx.Bool("show-remaining")))
 
 			return nil
 		},

--- a/internal/security/otp.go
+++ b/internal/security/otp.go
@@ -24,8 +24,10 @@ const (
 )
 
 // GenerateOTPCode generates a 6 digit TOTP from the secret Token.
-func GenerateOTPCode(token string, when time.Time, length uint) (string, error) {
+func GenerateOTPCode(token string, when time.Time, length uint) (string, int64, error) {
 	timer := uint64(math.Floor(float64(when.Unix()) / float64(timeSplitInSeconds)))
+	remainingTime := timeSplitInSeconds - when.Unix()%timeSplitInSeconds
+
 	// Remove spaces, some providers are giving us in a readable format,
 	// so they add spaces in there. If it's not removed while pasting in,
 	// remove it now.
@@ -36,7 +38,7 @@ func GenerateOTPCode(token string, when time.Time, length uint) (string, error) 
 
 	secretBytes, err := base32.StdEncoding.WithPadding(base32.NoPadding).DecodeString(token)
 	if err != nil {
-		return "", OTPError{Message: err.Error()}
+		return "", 0, OTPError{Message: err.Error()}
 	}
 
 	if length == 0 {
@@ -61,5 +63,5 @@ func GenerateOTPCode(token string, when time.Time, length uint) (string, error) 
 
 	format := fmt.Sprintf("%%0%dd", length)
 
-	return fmt.Sprintf(format, modulo), nil
+	return fmt.Sprintf(format, modulo), remainingTime, nil
 }

--- a/internal/security/otp_test.go
+++ b/internal/security/otp_test.go
@@ -2,9 +2,10 @@ package security_test
 
 import (
 	"encoding/base32"
-	"github.com/yitsushi/totp-cli/internal/storage"
 	"testing"
 	"time"
+
+	"github.com/yitsushi/totp-cli/internal/storage"
 
 	"github.com/stretchr/testify/assert"
 
@@ -24,7 +25,7 @@ func TestGenerateOTPCode(t *testing.T) {
 	}
 
 	for when, expected := range table {
-		code, err := security.GenerateOTPCode(input, when, storage.DefaultTokenLength)
+		code, _, err := security.GenerateOTPCode(input, when, storage.DefaultTokenLength)
 
 		assert.NoError(t, err)
 		assert.Equal(t, expected, code, when.String())
@@ -44,7 +45,7 @@ func TestGenerateOTPCode_length8(t *testing.T) {
 	}
 
 	for when, expected := range table {
-		code, err := security.GenerateOTPCode(input, when, 8)
+		code, _, err := security.GenerateOTPCode(input, when, 8)
 
 		assert.NoError(t, err)
 		assert.Equal(t, expected, code, when.String())
@@ -64,7 +65,7 @@ func TestGenerateOTPCode_SpaceSeparatedToken(t *testing.T) {
 	}
 
 	for when, expected := range table {
-		code, err := security.GenerateOTPCode(input, when, storage.DefaultTokenLength)
+		code, _, err := security.GenerateOTPCode(input, when, storage.DefaultTokenLength)
 
 		assert.NoError(t, err)
 		assert.Equal(t, expected, code, when.String())
@@ -84,7 +85,7 @@ func TestGenerateOTPCode_NonPaddedHashes(t *testing.T) {
 	}
 
 	for when, expected := range table {
-		code, err := security.GenerateOTPCode(input, when, storage.DefaultTokenLength)
+		code, _, err := security.GenerateOTPCode(input, when, storage.DefaultTokenLength)
 
 		assert.NoError(t, err)
 		assert.Equal(t, expected, code, when.String())
@@ -99,7 +100,7 @@ func TestGenerateOTPCode_InvaidPadding(t *testing.T) {
 	}
 
 	for when, expected := range table {
-		code, err := security.GenerateOTPCode(input, when, storage.DefaultTokenLength)
+		code, _, err := security.GenerateOTPCode(input, when, storage.DefaultTokenLength)
 
 		assert.Error(t, err)
 		assert.Equal(t, expected, code, when.String())


### PR DESCRIPTION
New flag on `generate` and `instant`:

```
❯ go run . generate --show-remaining namespace account
Password: ***
465669 (remaining time: 26s)
```

The default value is still false as a lot of users are using this tool as part of their CD/CI pipeline.

Closes #88

References:
* https://github.com/yitsushi/totp-cli/issues/88