### PR TITLE
fix: empty string when new newline at the end of stdin

### DIFF
--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -36,7 +36,7 @@ func (t Terminal) Read(prompt string) (string, error) {
 
 	text, readErr := reader.ReadString('\n')
 	if readErr != nil {
-		return "", fmt.Errorf("error reading from input: %w", readErr)
+		return text, fmt.Errorf("error reading from input: %w", readErr)
 	}
 
 	text = strings.TrimSpace(text)


### PR DESCRIPTION
The code reads the token from `stdin` until newline. If there is no newline, it counts the content as empty string.

We use `bufio.NewReader` with `reader.ReadString('\n')` which "reads until the first occurrence of delim in the input". When it can't find a newline character before the stream ends we return with an error and an empty string.

Fix: As `reader.ReadString` returns with the content before the error in all cases, we can return with the content even if we meet an error.

Note: We should check if the error was EOF on caller side everywhere.

Fixes #95

References:
* https://github.com/yitsushi/totp-cli/issues/95