### PR TITLE
docs: fix typos

### DIFF
--- a/internal/security/otp_test.go
+++ b/internal/security/otp_test.go
@@ -92,7 +92,7 @@ func TestGenerateOTPCode_NonPaddedHashes(t *testing.T) {
 	}
 }
 
-func TestGenerateOTPCode_InvaidPadding(t *testing.T) {
+func TestGenerateOTPCode_InvalidPadding(t *testing.T) {
 	input := "a6mr*&^&*%*&ylj|'[lbufszudtjdt42nh5by"
 	table := map[time.Time]string{
 		time.Date(1970, 1, 1, 0, 0, 59, 0, time.UTC):   "",

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -40,7 +40,7 @@ type Storage struct {
 	Namespaces []*Namespace
 }
 
-// DecryptV1 tries to decrypt the original unsecure SHA1 storage.
+// DecryptV1 tries to decrypt the original insecure SHA1 storage.
 func (s *Storage) DecryptV1() error {
 	encryptedData, err := os.ReadFile(s.File)
 	if err != nil {


### PR DESCRIPTION
Found via `typos --hidden --format brief` and `codespell -i3 -w -H`