### PR TITLE
feat: generate vendor archive for Gentoo packaging

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,9 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Create vendor directory
+        run: |
+          go mod vendor
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ totp-cli
 coverage.out
 .idea
 dist/
+vendor/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,6 +29,21 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
+  - id: vendor-package
+    format: tar.xz
+    meta: true
+    name_template: "{{ .ProjectName }}_vendor"
+    files:
+      - vendor/*
+      - vendor/**/*
+
+    # That's sad:
+    # This feature is only available in GoReleaser Pro.
+    #   hooks:
+    #     before:
+    #       - go mod vendor
+    #     after:
+    #       - rm -rf vendor
 
 changelog:
   sort: asc

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,7 +53,7 @@ changelog:
       - "^test:"
 
 signs:
-  - artifacts: checksum
+  - artifacts: all
     cmd: gpg2
     args:
       - "--batch"


### PR DESCRIPTION
On release, generate a `_vendor.tar.xz` archive, so a Gentoo package can
use proper vendoring without using third party repository or other sources.

Resolves #125

References:
- https://github.com/yitsushi/totp-cli/issues/125
- https://github.com/gentoo/guru/commit/23487b9ca561e1d9feca81ca2c1aa6f0cc1ebe90#commitcomment-142489696
- https://wiki.gentoo.org/wiki/Writing_go_Ebuilds