### PR TITLE
feat: support password command for YubiKey challenge-response

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,26 @@ If you save it in a variable it can be exposed if your `ENV` is exposed somehow,
 if you directly type in the password in the command line, it can end up in your
 bash/zsh/whatevershell history.
 
+### Password command
+
+If the password comes from another tool, use `--password-command`. The command
+is executed by your shell, and totp-cli uses its stdout as the storage password.
+The trailing line break is ignored.
+
+This can be used with a YubiKey configured for HMAC-SHA1 challenge-response,
+where the same challenge returns the same response every time:
+
+```shell
+ykman otp chalresp --touch --generate 2
+totp-cli \
+  --password-command 'ykman otp calculate 2 746f74702d636c69' \
+  list
+```
+
+Do not use Yubico OTP or HOTP keyboard output as the password source for this
+option. Those values change on every touch, so they cannot decrypt the same
+credentials file later.
+
 Mostly to support CI/CD automation, there is an option to set the
 password/passphrase as an environment variable. **Please use it only if you know
 the system is safe to store passwords in environment variables.**

--- a/app.go
+++ b/app.go
@@ -17,6 +17,8 @@ func newApplication() *cli.App {
 		HelpName: "totp-cli",
 		Usage:    "Authy/Google Authenticator like TOTP CLI tool written in Go.",
 		Version:  info.Version,
+		Flags:    cmd.GlobalFlags(),
+		Before:   cmd.PreparePassword,
 		Commands: []*cli.Command{
 			cmd.AddTokenCommand(),
 			cmd.ChangePasswordCommand(),

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -5,6 +5,22 @@ import (
 	"github.com/yitsushi/totp-cli/internal/security"
 )
 
+const passwordCommandFlagName = "password-command"
+
+// GlobalFlags returns flags that apply to every command.
+func GlobalFlags() []cli.Flag {
+	return []cli.Flag{
+		flagPasswordCommand(),
+	}
+}
+
+func flagPasswordCommand() *cli.StringFlag {
+	return &cli.StringFlag{
+		Name:  passwordCommandFlagName,
+		Usage: "Command that prints the storage password to stdout.",
+	}
+}
+
 func flagAlgorithm() *cli.StringFlag {
 	return &cli.StringFlag{
 		Name:  "algorithm",

--- a/internal/cmd/password_command.go
+++ b/internal/cmd/password_command.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+)
+
+type passwordCommandError string
+
+const (
+	errPasswordCommandEmpty    passwordCommandError = "password command is empty"
+	errPasswordCommandNoOutput passwordCommandError = "password command produced no password"
+)
+
+func (err passwordCommandError) Error() string {
+	return string(err)
+}
+
+// PreparePassword stores the output from --password-command for storage setup.
+func PreparePassword(ctx *cli.Context) error {
+	command := ctx.String(passwordCommandFlagName)
+	if command == "" {
+		return nil
+	}
+
+	password, err := readPasswordCommand(command)
+	if err != nil {
+		return err
+	}
+
+	if err = os.Setenv("TOTP_PASS", password); err != nil {
+		return fmt.Errorf("set password environment: %w", err)
+	}
+
+	return nil
+}
+
+func readPasswordCommand(command string) (string, error) {
+	if strings.TrimSpace(command) == "" {
+		return "", errPasswordCommandEmpty
+	}
+
+	cmd := shellCommand(command)
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("password command failed: %w", err)
+	}
+
+	password := strings.TrimRight(string(output), "\r\n")
+	if password == "" {
+		return "", errPasswordCommandNoOutput
+	}
+
+	return password, nil
+}
+
+func shellCommand(command string) *exec.Cmd {
+	if runtime.GOOS == "windows" {
+		return exec.CommandContext(context.Background(), "cmd", "/C", command)
+	}
+
+	return exec.CommandContext(context.Background(), "sh", "-c", command)
+}

--- a/internal/cmd/password_command_test.go
+++ b/internal/cmd/password_command_test.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadPasswordCommand(t *testing.T) {
+	password, err := readPasswordCommand("echo command-password")
+
+	require.NoError(t, err)
+	require.Equal(t, "command-password", password)
+}
+
+func TestReadPasswordCommandEmpty(t *testing.T) {
+	_, err := readPasswordCommand(" ")
+
+	require.EqualError(t, err, "password command is empty")
+}

--- a/internal/security/otp_test.go
+++ b/internal/security/otp_test.go
@@ -139,14 +139,14 @@ func (suite *GenerateOTPCodeTestSuite) TestInvalidPadding() {
 func (suite *GenerateOTPCodeTestSuite) TestSHA256() {
 	input := "JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP"
 	table := map[time.Time]string{
-		time.Date(1970, 1, 1, 0, 0, 59, 0, time.UTC):     "598909",
-		time.Date(2005, 3, 18, 1, 58, 29, 0, time.UTC):   "343094",
-		time.Date(2005, 3, 18, 1, 58, 31, 0, time.UTC):   "342278",
-		time.Date(2009, 2, 13, 23, 31, 30, 0, time.UTC):  "657794",
-		time.Date(2016, 9, 16, 12, 40, 12, 0, time.UTC):  "139801",
-		time.Date(2033, 5, 18, 3, 33, 20, 0, time.UTC):   "102968",
-		time.Date(2603, 10, 11, 11, 33, 20, 0, time.UTC): "625152",
-		time.Date(2025, 02, 26, 18, 12, 11, 0, time.UTC): "356698",
+		time.Date(1970, 1, 1, 0, 0, 59, 0, time.UTC):      "598909",
+		time.Date(2005, 3, 18, 1, 58, 29, 0, time.UTC):    "343094",
+		time.Date(2005, 3, 18, 1, 58, 31, 0, time.UTC):    "342278",
+		time.Date(2009, 2, 13, 23, 31, 30, 0, time.UTC):   "657794",
+		time.Date(2016, 9, 16, 12, 40, 12, 0, time.UTC):   "139801",
+		time.Date(2033, 5, 18, 3, 33, 20, 0, time.UTC):    "102968",
+		time.Date(2603, 10, 11, 11, 33, 20, 0, time.UTC):  "625152",
+		time.Date(2025, 0o2, 26, 18, 12, 11, 0, time.UTC): "356698",
 	}
 
 	for when, expected := range table {
@@ -165,14 +165,14 @@ func (suite *GenerateOTPCodeTestSuite) TestSHA256() {
 func (suite *GenerateOTPCodeTestSuite) TestSHA512() {
 	input := "JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP"
 	table := map[time.Time]string{
-		time.Date(1970, 1, 1, 0, 0, 59, 0, time.UTC):     "735781",
-		time.Date(2005, 3, 18, 1, 58, 29, 0, time.UTC):   "630426",
-		time.Date(2005, 3, 18, 1, 58, 31, 0, time.UTC):   "719335",
-		time.Date(2009, 2, 13, 23, 31, 30, 0, time.UTC):  "390343",
-		time.Date(2016, 9, 16, 12, 40, 12, 0, time.UTC):  "760292",
-		time.Date(2033, 5, 18, 3, 33, 20, 0, time.UTC):   "255524",
-		time.Date(2603, 10, 11, 11, 33, 20, 0, time.UTC): "041274",
-		time.Date(2025, 02, 26, 18, 12, 11, 0, time.UTC): "546487",
+		time.Date(1970, 1, 1, 0, 0, 59, 0, time.UTC):      "735781",
+		time.Date(2005, 3, 18, 1, 58, 29, 0, time.UTC):    "630426",
+		time.Date(2005, 3, 18, 1, 58, 31, 0, time.UTC):    "719335",
+		time.Date(2009, 2, 13, 23, 31, 30, 0, time.UTC):   "390343",
+		time.Date(2016, 9, 16, 12, 40, 12, 0, time.UTC):   "760292",
+		time.Date(2033, 5, 18, 3, 33, 20, 0, time.UTC):    "255524",
+		time.Date(2603, 10, 11, 11, 33, 20, 0, time.UTC):  "041274",
+		time.Date(2025, 0o2, 26, 18, 12, 11, 0, time.UTC): "546487",
 	}
 
 	for when, expected := range table {
@@ -191,14 +191,14 @@ func (suite *GenerateOTPCodeTestSuite) TestSHA512() {
 func (suite *GenerateOTPCodeTestSuite) TestSHA256WithLongerPeriod() {
 	input := "JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP"
 	table := map[time.Time]string{
-		time.Date(2025, 02, 26, 18, 12, 1, 0, time.UTC):  "195134",
-		time.Date(2025, 02, 26, 18, 12, 11, 0, time.UTC): "195134",
-		time.Date(2025, 02, 26, 18, 12, 23, 0, time.UTC): "195134",
-		time.Date(2025, 02, 26, 18, 12, 33, 0, time.UTC): "195134",
-		time.Date(2025, 02, 26, 18, 12, 43, 0, time.UTC): "195134",
-		time.Date(2025, 02, 26, 18, 12, 53, 0, time.UTC): "195134",
-		time.Date(2025, 02, 26, 18, 13, 3, 0, time.UTC):  "042795",
-		time.Date(2025, 02, 26, 18, 13, 13, 0, time.UTC): "042795",
+		time.Date(2025, 0o2, 26, 18, 12, 1, 0, time.UTC):  "195134",
+		time.Date(2025, 0o2, 26, 18, 12, 11, 0, time.UTC): "195134",
+		time.Date(2025, 0o2, 26, 18, 12, 23, 0, time.UTC): "195134",
+		time.Date(2025, 0o2, 26, 18, 12, 33, 0, time.UTC): "195134",
+		time.Date(2025, 0o2, 26, 18, 12, 43, 0, time.UTC): "195134",
+		time.Date(2025, 0o2, 26, 18, 12, 53, 0, time.UTC): "195134",
+		time.Date(2025, 0o2, 26, 18, 13, 3, 0, time.UTC):  "042795",
+		time.Date(2025, 0o2, 26, 18, 13, 13, 0, time.UTC): "042795",
 	}
 
 	for when, expected := range table {


### PR DESCRIPTION
## Summary

This updates the original approach for #77 based on maintainer feedback.

Instead of toggling behavior with `TOTP_YUBIKEY` or treating a Yubico OTP as a reusable password, this PR adds a global `--password-command` flag. The command's stdout is used as the storage password.

That allows a real YubiKey HMAC-SHA1 challenge-response setup, for example:

```shell
totp-cli --password-command 'ykman otp calculate 2 746f74702d636c69' list
```

Because the challenge is stable, the YubiKey response is stable too. The README now explicitly warns not to use Yubico OTP/HOTP keyboard output as the password source because those values change on every touch.

## Changes

- Added global `--password-command`
- Added command-output password handling before command execution
- Replaced the old `TOTP_YUBIKEY` documentation with challenge-response focused documentation
- Added unit coverage for password command handling
- Applied required formatter output to existing OTP tests so `make lint` passes

## Testing

- `go test ./...`
- `make lint`
